### PR TITLE
feat: Use Subdomains to populate form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # Local Netlify folder
 .netlify
+.history

--- a/client/src/components/Home/GetStartedForm.js
+++ b/client/src/components/Home/GetStartedForm.js
@@ -52,10 +52,29 @@ export default function GetStartedForm({toggle}) {
     }
   });
 
+  // On componentDidMount (when component is first loaded).
+  useEffect(() => {
+    autoSelectCounty();
+  }, []);
+
   // Clear out the 'Charity' combo if 'County' is changed
   useEffect( () => {
     setCharityId(0);
   }, [countyId]);
+
+  // If user arrives on subdomain and it is a valid county auto populate region
+  function autoSelectCounty() {
+    const host = window.location.host;
+    const subdomain = host.split(".")[0];
+    const normalizedSubdomain = subdomain.trim().toLowerCase();
+
+    for (const [, county] of Object.entries(counties)) {
+      const normalizedCountyName = county.name.toLowerCase();
+      if (normalizedCountyName === normalizedSubdomain) {
+        setCountyId(county.id);
+      }
+    }
+  }
 
   // Redirect the user to Subbly
   function handleSubmit() {


### PR DESCRIPTION
Using the subdomain, if it's a valid county, to pre-populate the (first) county field.
For example, if the user arrives on `bristol.charityshopexchange.com`
then `Bristol` will already be selected in the `Select a region` dropdown menu.

See #26.